### PR TITLE
Include body of error in RequestException

### DIFF
--- a/src/Proyecto26.RestClient/Utils/HttpBase.cs
+++ b/src/Proyecto26.RestClient/Utils/HttpBase.cs
@@ -61,7 +61,7 @@ namespace Proyecto26
         private static RequestException CreateException(UnityWebRequest request)
         {
             var message = request.error ?? request.downloadHandler.text;
-            return new RequestException(message, request.isHttpError, request.isNetworkError, request.responseCode);
+            return new RequestException(message + Environment.NewLine + request.downloadHandler.text, request.isHttpError, request.isNetworkError, request.responseCode);
         }
 
         private static void DebugLog(bool debugEnabled, object message, bool isError)


### PR DESCRIPTION
Often times error's body include very useful info. I guess this is not the cleanest way but you get the idea.