### PR TITLE
Add ParseResponseBody option to fix severe frame rate drop when parsing large response

### DIFF
--- a/src/Proyecto26.RestClient/Helpers/Common.cs
+++ b/src/Proyecto26.RestClient/Helpers/Common.cs
@@ -34,8 +34,18 @@ namespace Proyecto26.Common
                 request.uploadHandler = (UploadHandler)new UploadHandlerRaw(bodyRaw);
                 request.uploadHandler.contentType = contentType;
             }
+
             if (options.DownloadHandler is DownloadHandler)
+            {
                 request.downloadHandler = options.DownloadHandler;
+                if (options.DownloadHandler is DownloadHandlerFile
+                    || options.DownloadHandler is DownloadHandlerTexture
+                    || options.DownloadHandler is DownloadHandlerAssetBundle
+                    || options.DownloadHandler is DownloadHandlerAudioClip)
+                {
+                    options.ParseResponseBody = false;
+                }
+            }
             else
                 request.downloadHandler = (DownloadHandler)new DownloadHandlerBuffer();
             if (!string.IsNullOrEmpty(contentType))

--- a/src/Proyecto26.RestClient/Helpers/RequestHelper.cs
+++ b/src/Proyecto26.RestClient/Helpers/RequestHelper.cs
@@ -235,5 +235,15 @@ namespace Proyecto26
             }
             set { _headers = value; } 
         }
+
+        private bool _parseResponseBody = true;
+        /// <summary>
+        /// Whether to parse the response body as JSON or not. Note: parsing a large non-text file will have severe performance impact.
+        /// </summary>
+        public bool ParseResponseBody
+        {
+            get { return _parseResponseBody; }
+            set { _parseResponseBody = value; }
+        }
     }
 }


### PR DESCRIPTION
The following code easily freezes the editor once the download is completed:
```
RestClient.Get(new RequestHelper {
    Uri = "https://github.com/pytorch/pytorch/archive/v1.1.0.zip"
});
```

![image](https://user-images.githubusercontent.com/3406505/62676622-78c70100-b979-11e9-8ed8-0f8fe80c2175.png)

The reason is that RestClient uses `UnityWebRequest.Text` in HttpBase several times for parsing as JSON and logging debug info. However, this has severe performance impact if the downloaded data is very large and non-text:

![image](https://user-images.githubusercontent.com/3406505/62676853-2df9b900-b97a-11e9-9b67-503032232d07.png)

This PR adds a new option, `ParseResponseBody`, to RequestHelper. This option is by default `true`, but will be automatically set to `false` when `RequestHelper.DownloadHandler` is set to any instance of `DownloadHandlerFile`, `DownloadHandlerTexture`, `DownloadHandlerAssetBundle`, `DownloadHandlerAudioClip` - if the user specifies those as the download handler, they probably don't want to encode the downloaded data and parse it as JSON.

The above spike disappears with this change when testing on Unity 2019.1.10f1. Any feedback will be appreciated!