### PR TITLE
fix new obsoletion warning in unity 2019.3

### DIFF
--- a/src/Proyecto26.RestClient/Helpers/Common.cs
+++ b/src/Proyecto26.RestClient/Helpers/Common.cs
@@ -58,10 +58,12 @@ namespace Proyecto26.Common
             {
                 request.timeout = options.Timeout.Value;
             }
+#if !UNITY_2019_3_OR_NEWER
             if (options.ChunkedTransfer.HasValue)
             {
                 request.chunkedTransfer = options.ChunkedTransfer.Value;
             }
+#endif
             if (options.UseHttpContinue.HasValue)
             {
                 request.useHttpContinue = options.UseHttpContinue.Value;

--- a/src/Proyecto26.RestClient/Helpers/RequestHelper.cs
+++ b/src/Proyecto26.RestClient/Helpers/RequestHelper.cs
@@ -117,6 +117,7 @@ namespace Proyecto26
             set { _enableDebug = value; }
         }
 
+#if !UNITY_2019_3_OR_NEWER
         private bool? _chunkedTransfer;
         /// <summary>
         /// Indicates whether the UnityWebRequest system should employ the HTTP/1.1 chunked-transfer encoding method.
@@ -126,6 +127,7 @@ namespace Proyecto26
             get { return _chunkedTransfer; }
             set { _chunkedTransfer = value; }
         }
+#endif
 
         private bool? _useHttpContinue = true;
         /// <summary>


### PR DESCRIPTION
UnityWebRequest.chunkedTransfer got marked as a obsolete in unity 2019.3

this closes https://github.com/proyecto26/RestClient/issues/110