### PR TITLE
Retry on HTTP error

### DIFF
--- a/src/Proyecto26.RestClient/Helpers/HttpBase.cs
+++ b/src/Proyecto26.RestClient/Helpers/HttpBase.cs
@@ -23,7 +23,7 @@ namespace Proyecto26
                         callback(null, response);
                         break;
                     }
-                    else if (!options.IsAborted && retries < options.Retries)
+                    else if (!options.IsAborted && retries < options.Retries && request.isNetworkError)
                     {
                         yield return new WaitForSeconds(options.RetrySecondsDelay);
                         retries++;


### PR DESCRIPTION
When there was a 404 error for example it would retry the request, but this should not be the case since it will just come back with the same error. It should only retry when there is a network error.