### PR TITLE
Fix: Handle HTTP NO CONTENT status code (204) to prevent null reference exceptions in HttpBase.cs

### DIFF
--- a/src/Proyecto26.RestClient/Helpers/HttpBase.cs
+++ b/src/Proyecto26.RestClient/Helpers/HttpBase.cs
@@ -8,6 +8,8 @@ namespace Proyecto26
 {
     public static class HttpBase
     {
+        public static int HTTP_NO_CONTENT = 204;
+
         public static IEnumerator CreateRequestAndRetry(RequestHelper options, Action<RequestException, ResponseHelper> callback)
         {
 
@@ -118,7 +120,7 @@ namespace Proyecto26
                 var body = default(TResponse);
                 try
                 {
-                    if (err == null && res.Data != null && options.ParseResponseBody)
+                    if (err == null && res.StatusCode != HTTP_NO_CONTENT && res.Data != null && options.ParseResponseBody)
                         body = JsonUtility.FromJson<TResponse>(res.Text);
                 }
                 catch (Exception error)
@@ -139,7 +141,7 @@ namespace Proyecto26
                 var body = default(TResponse[]);
                 try
                 {
-                    if (err == null && res.Data != null && options.ParseResponseBody)
+                    if (err == null && res.StatusCode != HTTP_NO_CONTENT && res.Data != null && options.ParseResponseBody)
                         body = JsonHelper.ArrayFromJson<TResponse>(res.Text);
                 }
                 catch (Exception error)


### PR DESCRIPTION
NO_CONTENT is not considered as being an error in the HTTP standard, and therefore previous code would try to parse body data even with a NO_CONTENT being returned, leading to a parsing exception.

This is because as NO_CONTENT is not an error, returning an empty Response Body with a 204 status code does not return false for _UnityWebRequest.isHttpError_ which is used in Extensions.IsValidRequest() to know if an exception must be thrown or not.

Various backend frameworks use NO_CONTENT as a way to gracefully indicates that a specific resource is empty (for instance, if you try to get the list of items in a player's inventory and the inventory is empty).

This PR just checks for the status code before trying to parse the response body in HttpBase.cs. 

It is a very lightweight fix and should not break projects using the library because it's due to how UnityWebRequest handles HTTP codes (UnityWebRequest.isHttpError won't return true for a 204 NO_CONTENT).