### PR TITLE
Created asmdef for sample + moved the sample to unity recommended directory (Samples~ instead of sample)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
         ls
         git config --global user.name 'github-bot'
         git config --global user.email 'github-bot@users.noreply.github.com'
-        git commit -am "create release folder"
         git subtree split -P "$NUGET_ROOT" -b nuget                     # create the nuget branch
         git checkout nuget                                              # checkout the branch
         git commit -am "fix: src => root"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
         git branch -d upm &> /dev/null || echo upm branch not found # recreate the upm branch each time
         git mv "$PKG_ROOT" "src/$UPM_ROOT"
         git mv "src/$UPM_ROOT" .
-        git mv demo/Assets demo/Sample
-        git mv demo/Sample $UPM_ROOT
+        git mv demo/Assets demo/Samples~
+        git mv demo/Samples~ $UPM_ROOT
         git mv doc Docs
         git mv Docs $UPM_ROOT
         git mv LICENSE $UPM_ROOT
@@ -34,11 +34,11 @@ jobs:
         git commit -m "create release folder"
         git subtree split -P "$UPM_ROOT" -b upm                     # create the upm branch
         git checkout upm                                            # checkout the branch
-        if [[ -d "Sample/Packages" ]]; then
-          git rm -rf Sample/Packages
-          git rm Sample/Packages.meta --ignore-unmatch
-          git rm Sample/packages.config
-          git rm Sample/packages.config.meta --ignore-unmatch
+        if [[ -d "Samples~/Packages" ]]; then
+          git rm -rf Samples~/Packages
+          git rm Samples~/Packages.meta --ignore-unmatch
+          git rm Samples~/packages.config
+          git rm Samples~/packages.config.meta --ignore-unmatch
         fi
         if [[ -d "Properties" ]]; then
           git rm -rf Properties

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - master
-  workflow_dispatch:
 jobs:
   split-upm:
     name: split upm branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - master
+  workflow_dispatch:
 jobs:
   split-upm:
     name: split upm branch

--- a/src/Proyecto26.RestClient/Proyecto26.RestClient.asmdef.meta
+++ b/src/Proyecto26.RestClient/Proyecto26.RestClient.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fbfbf4d8d5c249a458d69ae047a2fbd2
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Proyecto26.RestClient/Proyecto26.RestClient.nuspec
+++ b/src/Proyecto26.RestClient/Proyecto26.RestClient.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>Proyecto26.RestClient</id>
-    <version>2.6.1</version>
+    <version>2.6.2</version>
     <title>RestClient for Unity</title>
     <authors>Juan David Nicholls Cardona</authors>
     <owners>jdnichollsc</owners>
@@ -11,7 +11,13 @@
     <iconUrl>https://github.com/proyecto26/RestClient/blob/master/img/icono.png?raw=true</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Simple HTTP and REST client for Unity based on Promises, also support Callbacks!</description>
-    <releaseNotes>Add ParseResponseBody option to fix severe frame rate drop when parsing large response</releaseNotes>
+    <releaseNotes>Include:
+- Add a progress reporting callback
+- Add support for PATCH verb
+- Add solution to make network call on main thread
+- Changes to use RetryCallback to handle token expiration
+- Handle HTTP NO CONTENT status code (204) to prevent null reference exceptions
+- Removing Depricated APIs</releaseNotes>
     <copyright>Copyright ©2019 Proyecto 26</copyright>
     <tags>Unity Promises Http Rest http-client HttpClient rest-client RestClient Request API Requests APIs JSON Networking</tags>
     <dependencies>

--- a/src/Proyecto26.RestClient/package.json
+++ b/src/Proyecto26.RestClient/package.json
@@ -38,7 +38,7 @@
     {
       "displayName": "Sample",
       "description": "RestClient Sample",
-      "path": "Sample"
+      "path": "Samples~"
     }
   ]
 }

--- a/src/Proyecto26.RestClient/package.json
+++ b/src/Proyecto26.RestClient/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.proyecto26.restclient",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "displayName": "RestClient for Unity",
   "description": "Simple HTTP and REST client for Unity based on Promises, also support Callbacks!",
   "unity": "2017.1",

--- a/src/Proyecto26.RestClient/package.json
+++ b/src/Proyecto26.RestClient/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.proyecto26.restclient",
-  "version": "2.6.3",
+  "version": "2.6.2",
   "displayName": "RestClient for Unity",
   "description": "Simple HTTP and REST client for Unity based on Promises, also support Callbacks!",
   "unity": "2017.1",


### PR DESCRIPTION
1. Before this change, when importing package, the package was fetching the sample directory as part of the package.
  Moving sample to special named directory `Samples~` (https://docs.unity3d.com/Manual/cus-samples.html) will force the unity package manager UPM to skip this directory when importing package. An option to download sample is still visible in the UPM under RestClient package.
2. The sample uses RestClient package, therefore another asmdef was created for sample with dependency to RestClient.

Known problems: 
1. **Only when optionally downloading the sample:** The sample can't find method: CleanDefaultHandlers - I don't know why
`Assets\Samples\RestClient for Unity\2.6.2\Sample\MainScript.cs(48,15): error CS0117: 'RestClient' does not contain a definition for 'CleanDefaultHeaders'`