### PR TITLE
Fix HEAD promise method incorrectly calling DELETE

### DIFF
--- a/src/Proyecto26.RestClient/RestClientPromise.cs
+++ b/src/Proyecto26.RestClient/RestClientPromise.cs
@@ -381,7 +381,7 @@ namespace Proyecto26
         /// <param name="url">A string containing the URL to which the request is sent.</param>
         public static IPromise<ResponseHelper> Head(string url)
         {
-            return Delete(new RequestHelper { Uri = url });
+            return Head(new RequestHelper { Uri = url });
         }
 
         /// <summary>


### PR DESCRIPTION
Calling the `Head(string url)` overloaded method would incorrectly send a `DELETE` request when attempting to fetch the response headers.